### PR TITLE
[PR] Using cid with entry upload metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ npm-debug.log
 /assets/node_modules/
 
 .env
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -1626,14 +1626,14 @@ and locate the `presign_upload/2`.
 Change the `key` variable to the following:
 
 ```elixir
-    key = Cid.cid("#{DateTime.utc_now() |> DateTime.to_iso8601()}_#{entry.client_name}")
+    # Create `CID` from file content metadata
+    file_cid = Cid.cid(%{name: entry.client_name, path: entry.client_relative_path, size: entry.client_size, type: entry.client_type})
+    key = "#{file_cid}.#{Enum.at(MIME.extensions(entry.client_type), 0)}"
 ```
 
 We are creating a 
 [`CID`](https://docs.ipfs.tech/concepts/content-addressing/)
-from a string with the format 
-`currentdate_filename`.
-This is the new filename. 
+from the upload entry metadata of the uploaded file.
 
 If you run `mix phx.server`
 and upload a file,

--- a/lib/app_web/live/imgup_live.ex
+++ b/lib/app_web/live/imgup_live.ex
@@ -15,7 +15,10 @@ defmodule AppWeb.ImgupLive do
     uploads = socket.assigns.uploads
     bucket_original = "imgup-original"
     bucket_compressed = "imgup-compressed"
-    key = Cid.cid("#{DateTime.utc_now() |> DateTime.to_iso8601()}_#{entry.client_name}")
+
+    # Create `CID` from file content metadata
+    file_cid = Cid.cid(%{name: entry.client_name, path: entry.client_relative_path, size: entry.client_size, type: entry.client_type})
+    key = "#{file_cid}.#{Enum.at(MIME.extensions(entry.client_type), 0)}"
 
     config = %{
       region: "eu-west-3",


### PR DESCRIPTION
fixes #62 

This changes how the `CID` is created with the entry data. It uses the entry's name, the relative path, the size and the content type to try and generate a `CID` closest to the file's contents with its metadata.

Unfortunately, we cannot use the file's contents to create a `CID` because, with this method (as described in the [LiveView's documentation](https://hexdocs.pm/phoenix_live_view/uploads.html), which is _different from the [regular file upload-way that is used in the API](https://hexdocs.pm/phoenix/file_uploads.html)_) we do not have access to the file's contents.
I've tried doing this in both LiveView and also in the `js` client but there is no information about where the File is stored (it's not stored anywhere). I've also tried checking if there's a discernable way of seeing the contents of the file in the entry that is used in the Javascript client (e.g. check the screenshot below)

<img width="466" alt="image" src="https://github.com/dwyl/imgup/assets/17494745/38219d46-1d00-4030-953c-a704ddd22912">

So the closest we can do with the LiveView format is to use its metadata and create the `CID` off of that.