### PR TITLE
[PR] Fixing black borders. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1935,10 +1935,10 @@ exports.handler = async (event) => {
     // Compress the image to a 200x200 avatar square as a buffer, without stretching
     const compressedImageBuffer = await sharp(uncompressedImage.Body)
     .resize({ 
-        width: 200, 
         height: 200, 
         fit: 'contain'
     })
+    .png()
     .toBuffer();
 
     // Upload the compressed image buffer to the Compressed Images bucket
@@ -1946,7 +1946,7 @@ exports.handler = async (event) => {
         Bucket: process.env.COMPRESSED_BUCKET,
         Key: key,
         Body: compressedImageBuffer,
-        ContentType: "image",
+        ContentType: "image/png",
         ACL: 'public-read'
     }).promise();
 

--- a/an_aws_sam_imgup-compressor/src/index.js
+++ b/an_aws_sam_imgup-compressor/src/index.js
@@ -18,10 +18,10 @@ exports.handler = async (event) => {
     // Compress the image to a 200x200 avatar square as a buffer, without stretching
     const compressedImageBuffer = await sharp(uncompressedImage.Body)
     .resize({ 
-        width: 200, 
         height: 200, 
         fit: 'contain'
     })
+    .png()
     .toBuffer();
 
     // Upload the compressed image buffer to the Compressed Images bucket
@@ -29,7 +29,7 @@ exports.handler = async (event) => {
         Bucket: process.env.COMPRESSED_BUCKET,
         Key: key,
         Body: compressedImageBuffer,
-        ContentType: "image",
+        ContentType: "image/png",
         ACL: 'public-read'
     }).promise();
 


### PR DESCRIPTION
closes #66 
closes #72

This fixes the black border issue on #66 and images not displaying on sites like Github, as described in #72.

The new version has already been deployed, so it works properly.
Here's an example of a compressed picture without a black border and showing properly on Github.

![demo](https://imgup-compressed.s3-eu-west-3.amazonaws.com/zb2rheBAjJ4fx5HZJNRwNLuYhaTUzoGu6e111Nymiv4pCBioL)