### PR TITLE
[PR] Buckets are now fetched from env variable.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: eu-west-3
+        AWS_ORIGINAL_BUCKET: imgup-original
+        AWS_COMPRESSED_BUCKET: imgup-compressed
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/config/config.exs
+++ b/config/config.exs
@@ -54,6 +54,8 @@ config :ex_aws,
   access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
   secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
   region: System.get_env("AWS_REGION"),
+  original_bucket: System.get_env("AWS_ORIGINAL_BUCKET"),
+  compressed_bucket: System.get_env("AWS_COMPRESSED_BUCKET"),
   request_config_override: %{}
 
 # Import environment specific config. This must remain at the bottom

--- a/lib/app/upload.ex
+++ b/lib/app/upload.ex
@@ -4,7 +4,7 @@ defmodule App.Upload do
   """
   import SweetXml
 
-  @compressed_baseurl "https://s3.eu-west-3.amazonaws.com/imgup-compressed/"
+  @compressed_baseurl "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :compressed_bucket)}/"
 
   @doc """
   `upload/1` receives an `image` with the format
@@ -30,7 +30,7 @@ defmodule App.Upload do
     {:ok, body} =
       image.path
       |> ExAws.S3.Upload.stream_file()
-      |> ExAws.S3.upload("imgup-original", file_name, acl: :public_read, content_type: image.content_type )
+      |> ExAws.S3.upload(Application.get_env(:ex_aws, :original_bucket), file_name, acl: :public_read, content_type: image.content_type )
       |> ExAws.request(get_ex_aws_request_config_override())
 
     # Sample response:

--- a/lib/app_web/live/imgup_live.ex
+++ b/lib/app_web/live/imgup_live.ex
@@ -19,8 +19,8 @@ defmodule AppWeb.ImgupLive do
 
   defp presign_upload(entry, socket) do
     uploads = socket.assigns.uploads
-    bucket_original = "imgup-original"
-    bucket_compressed = "imgup-compressed"
+    bucket_original = Application.get_env(:ex_aws, :original_bucket)
+    bucket_compressed = Application.get_env(:ex_aws, :compressed_bucket)
     key = Cid.cid("#{DateTime.utc_now() |> DateTime.to_iso8601()}_#{entry.client_name}")
 
     config = %{

--- a/test/app/upload_test.exs
+++ b/test/app/upload_test.exs
@@ -10,9 +10,9 @@ defmodule App.UploadTest do
 
     expected_response = %{
       compressed_url:
-        "https://s3.eu-west-3.amazonaws.com/imgup-compressed/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png",
+        "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :compressed_bucket)}/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png",
       url:
-        "https://s3.eu-west-3.amazonaws.com/imgup-original/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png"
+        "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :original_bucket)}/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png"
     }
 
     assert App.Upload.upload(image) == {:ok, expected_response}

--- a/test/app_web/api_test.exs
+++ b/test/app_web/api_test.exs
@@ -42,9 +42,9 @@ defmodule AppWeb.APITest do
 
     expected = %{
       "compressed_url" =>
-        "https://s3.eu-west-3.amazonaws.com/imgup-compressed/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png",
+        "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :compressed_bucket)}/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png",
       "url" =>
-        "https://s3.eu-west-3.amazonaws.com/imgup-original/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png"
+        "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :original_bucket)}/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png"
     }
 
     assert Jason.decode!(response(conn, 200)) == expected
@@ -55,9 +55,9 @@ defmodule AppWeb.APITest do
 
     expected = %{
       "compressed_url" =>
-        "https://s3.eu-west-3.amazonaws.com/imgup-compressed/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png",
+        "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :compressed_bucket)}/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png",
       "url" =>
-        "https://s3.eu-west-3.amazonaws.com/imgup-original/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png"
+        "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :original_bucket)}/zb2rhXACvyoVCaV1GF5ozeoNCXYdxcKAEWvBTpsnabo3moYwB.png"
     }
 
     assert Jason.decode!(response(conn, 200)) == expected


### PR DESCRIPTION
closes #80 

The names of the buckets are now fetched from env variables.
They are used across the application now.

The Github Action workflow file has also been changed to take into account this variable. So the deployed version should also work.