### PR TITLE
[PR] Fix deploying env vars issue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,6 +50,7 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# https://github.com/dwyl/imgup/issues/68
 config :ex_aws,
   access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
   secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -16,10 +16,3 @@ config :logger, level: :info
 
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.
-
-# https://github.com/dwyl/imgup/issues/68
-config :ex_aws,
-  access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
-  secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
-  region: System.get_env("AWS_REGION"),
-  request_config_override: %{}

--- a/lib/app_web/live/imgup_live.ex
+++ b/lib/app_web/live/imgup_live.ex
@@ -19,8 +19,8 @@ defmodule AppWeb.ImgupLive do
 
   defp presign_upload(entry, socket) do
     uploads = socket.assigns.uploads
-    bucket_original = Application.get_env(:ex_aws, :original_bucket)
-    bucket_compressed = Application.get_env(:ex_aws, :compressed_bucket)
+    bucket_original = Application.compile_env(:ex_aws, :original_bucket)
+    bucket_compressed = Application.compile_env(:ex_aws, :compressed_bucket)
     key = Cid.cid("#{DateTime.utc_now() |> DateTime.to_iso8601()}_#{entry.client_name}")
 
     config = %{

--- a/lib/app_web/live/imgup_live.ex
+++ b/lib/app_web/live/imgup_live.ex
@@ -19,8 +19,8 @@ defmodule AppWeb.ImgupLive do
 
   defp presign_upload(entry, socket) do
     uploads = socket.assigns.uploads
-    bucket_original = Application.compile_env(:ex_aws, :original_bucket)
-    bucket_compressed = Application.compile_env(:ex_aws, :compressed_bucket)
+    bucket_original = Application.get_env(:ex_aws, :original_bucket)
+    bucket_compressed = Application.get_env(:ex_aws, :compressed_bucket)
     key = Cid.cid("#{DateTime.utc_now() |> DateTime.to_iso8601()}_#{entry.client_name}")
 
     config = %{


### PR DESCRIPTION
closes #88

This should fix the deploying issues we've been having. The `prod` config file was incomplete. Because `config` should be used in a more generalized way and is valid for both `test` and `prod` environments, the full configuration of `ex_aws` is found there.

https://elixirforum.com/t/when-does-runtime-exs-make-more-sense/34812