### PR TITLE
[PR] Adding env variables to deploy workflow so `compile_env` works.

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -15,3 +15,6 @@ jobs:
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          AWS_REGION: eu-west-3
+          AWS_S3_BUCKET_ORIGINAL: imgup-original
+          AWS_S3_BUCKET_COMPRESSED: imgup-compressed

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [ main ]
 jobs:
   deploy:
     name: Deploy app

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -5,8 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [ main ]
+
 jobs:
   deploy:
     name: Deploy app

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -5,7 +5,8 @@ on:
   push:
     branches:
       - main
-
+  pull_request:
+    branches: [ main ]
 jobs:
   deploy:
     name: Deploy app
@@ -16,6 +17,3 @@ jobs:
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-          AWS_REGION: eu-west-3
-          AWS_S3_BUCKET_ORIGINAL: imgup-original
-          AWS_S3_BUCKET_COMPRESSED: imgup-compressed

--- a/api.md
+++ b/api.md
@@ -681,6 +681,11 @@ making it simpler!
 
 
 ```elixir
+
+  @original_bucket Application.get_env(:ex_aws, :original_bucket)
+  @compressed_bucket Application.get_env(:ex_aws, :compressed_bucket)
+  @compressed_baseurl "https://s3.eu-west-3.amazonaws.com/#{@compressed_bucket}/"
+
   def upload(image) do
     with {:ok, {file_cid, file_extension}} <- check_file_binary_and_extension(image),
          {:ok, {file_name, upload_response_body}} <-

--- a/api.md
+++ b/api.md
@@ -681,11 +681,6 @@ making it simpler!
 
 
 ```elixir
-
-  @original_bucket Application.get_env(:ex_aws, :original_bucket)
-  @compressed_bucket Application.get_env(:ex_aws, :compressed_bucket)
-  @compressed_baseurl "https://s3.eu-west-3.amazonaws.com/#{@compressed_bucket}/"
-
   def upload(image) do
     with {:ok, {file_cid, file_extension}} <- check_file_binary_and_extension(image),
          {:ok, {file_name, upload_response_body}} <-

--- a/api.md
+++ b/api.md
@@ -650,7 +650,7 @@ add:
       {:ok, upload_response_body} =
         image.path
         |> ExAws.S3.Upload.stream_file()
-        |> ExAws.S3.upload(@original_bucket, file_name,
+        |> ExAws.S3.upload(Application.get_env(:ex_aws, :original_bucket), file_name,
           acl: :public_read,
           content_type: image.content_type
         )
@@ -715,8 +715,13 @@ making it simpler!
       # Fetch the contents of the returned XML string from `ex_aws`.
       # This XML is parsed with `sweet_xml`:
       # github.com/kbrw/sweet_xml#the-x-sigil
+      #
+      # Fetching the URL of the returned file.
       url = upload_response_body.body |> xpath(~x"//text()") |> List.to_string()
-      compressed_url = "#{@compressed_baseurl}#{file_name}"
+
+      # Creating the compressed URL to return as well
+      compressed_bucket_baseurl = "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :compressed_bucket)}/"
+      compressed_url = "#{compressed_bucket_baseurl}#{file_name}"
       {:ok, %{url: url, compressed_url: compressed_url}}
     else
       {:error, reason} -> {:error, reason}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -65,10 +65,10 @@ if config_env() == :prod do
 
   # https://github.com/dwyl/imgup/issues/68
   config :ex_aws,
-  access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
-  secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
-  region: System.get_env("AWS_REGION"),
-  original_bucket: System.get_env("AWS_S3_BUCKET_ORIGINAL"),
-  compressed_bucket: System.get_env("AWS_S3_BUCKET_COMPRESSED"),
-  request_config_override: %{}
+    access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
+    secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
+    region: System.get_env("AWS_REGION"),
+    original_bucket: System.get_env("AWS_S3_BUCKET_ORIGINAL"),
+    compressed_bucket: System.get_env("AWS_S3_BUCKET_COMPRESSED"),
+    request_config_override: %{}
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -65,10 +65,10 @@ if config_env() == :prod do
 
   # https://github.com/dwyl/imgup/issues/68
   config :ex_aws,
-    access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
-    secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
-    region: System.get_env("AWS_REGION"),
-    original_bucket: System.get_env("AWS_S3_BUCKET_ORIGINAL"),
-    compressed_bucket: System.get_env("AWS_S3_BUCKET_COMPRESSED"),
-    request_config_override: %{}
+  access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
+  secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
+  region: System.get_env("AWS_REGION"),
+  original_bucket: System.get_env("AWS_S3_BUCKET_ORIGINAL"),
+  compressed_bucket: System.get_env("AWS_S3_BUCKET_COMPRESSED"),
+  request_config_override: %{}
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,12 +25,3 @@ config :logger, level: :warning
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
-
-# https://github.com/dwyl/imgup/issues/68
-config :ex_aws,
-  access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
-  secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
-  region: System.get_env("AWS_REGION"),
-  original_bucket: System.get_env("AWS_S3_BUCKET_ORIGINAL"),
-  compressed_bucket: System.get_env("AWS_S3_BUCKET_COMPRESSED"),
-  request_config_override: %{}

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,3 +25,12 @@ config :logger, level: :warning
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
+
+# https://github.com/dwyl/imgup/issues/68
+config :ex_aws,
+  access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
+  secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
+  region: System.get_env("AWS_REGION"),
+  original_bucket: System.get_env("AWS_S3_BUCKET_ORIGINAL"),
+  compressed_bucket: System.get_env("AWS_S3_BUCKET_COMPRESSED"),
+  request_config_override: %{}

--- a/lib/app/upload.ex
+++ b/lib/app/upload.ex
@@ -5,10 +5,6 @@ defmodule App.Upload do
   import SweetXml
   require Logger
 
-  @original_bucket Application.get_env(:ex_aws, :original_bucket)
-  @compressed_bucket Application.get_env(:ex_aws, :compressed_bucket)
-  @compressed_baseurl "https://s3.eu-west-3.amazonaws.com/#{@compressed_bucket}/"
-
   @doc """
   `upload/1` receives an `image` with the format
   %{
@@ -48,8 +44,13 @@ defmodule App.Upload do
       # Fetch the contents of the returned XML string from `ex_aws`.
       # This XML is parsed with `sweet_xml`:
       # github.com/kbrw/sweet_xml#the-x-sigil
+      #
+      # Fetching the URL of the returned file.
       url = upload_response_body.body |> xpath(~x"//text()") |> List.to_string()
-      compressed_url = "#{@compressed_baseurl}#{file_name}"
+
+      # Creating the compressed URL to return as well
+      compressed_bucket_baseurl = "https://s3.eu-west-3.amazonaws.com/#{Application.get_env(:ex_aws, :compressed_bucket)}/"
+      compressed_url = "#{compressed_bucket_baseurl}#{file_name}"
       {:ok, %{url: url, compressed_url: compressed_url}}
     else
       {:error, reason} -> {:error, reason}
@@ -67,7 +68,7 @@ defmodule App.Upload do
       {:ok, upload_response_body} =
         image.path
         |> ExAws.S3.Upload.stream_file()
-        |> ExAws.S3.upload(@original_bucket, file_name,
+        |> ExAws.S3.upload(Application.get_env(:ex_aws, :original_bucket), file_name,
           acl: :public_read,
           content_type: image.content_type
         )

--- a/lib/app/upload.ex
+++ b/lib/app/upload.ex
@@ -5,8 +5,8 @@ defmodule App.Upload do
   import SweetXml
   require Logger
 
-  @original_bucket Application.compile_env(:ex_aws, :original_bucket)
-  @compressed_bucket Application.compile_env(:ex_aws, :compressed_bucket)
+  @original_bucket Application.get_env(:ex_aws, :original_bucket)
+  @compressed_bucket Application.get_env(:ex_aws, :compressed_bucket)
   @compressed_baseurl "https://s3.eu-west-3.amazonaws.com/#{@compressed_bucket}/"
 
   @doc """


### PR DESCRIPTION
This should solve the issue where `compile_env` variables used in the code are not being properly initialized when building and deploying to `fly.io`.