### PR TITLE
[PR] Fixing upload failing

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,7 +50,6 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/app/upload.ex
+++ b/lib/app/upload.ex
@@ -2,7 +2,6 @@ defmodule App.Upload do
   @moduledoc """
   Handles uploading to S3 in a convenient reusable (DRY) function.
   """
-  import SweetXml
   require Logger
 
   # function gets cached
@@ -26,7 +25,6 @@ defmodule App.Upload do
     with {:ok, {file_cid, file_extension}} <- check_file_binary_and_extension(image),
          {:ok, {file_name, upload_response_body}} <-
            upload_file_to_s3(file_cid, file_extension, image) do
-
       # Fetching the URL of the returned file.
       url = upload_response_body.body.location
 

--- a/lib/app/upload.ex
+++ b/lib/app/upload.ex
@@ -26,33 +26,9 @@ defmodule App.Upload do
     with {:ok, {file_cid, file_extension}} <- check_file_binary_and_extension(image),
          {:ok, {file_name, upload_response_body}} <-
            upload_file_to_s3(file_cid, file_extension, image) do
-      # Sample AWS S3 XML response:
-      # %{
-      #   body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n
-      #    <CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-      #    <Location>https://s3.eu-west-3.amazonaws.com/imgup-original/qvWtbC7WaT.jpg</Location>
-      #    <Bucket>imgup-original</Bucket><Key>qvWtbC7WaT.jpg</Key>
-      #    <ETag>\"4ecd62951576b7e5b4a3e869e5e98a0f-1\"</ETag></CompleteMultipartUploadResult>",
-      #   headers: [
-      #     {"x-amz-id-2",
-      #      "wNTNZKt82vgnOuT1o2Tz8z3gcRzd6wXofYxQmBUkGbBGTpmv1WbwjjGiRAUtOTYIm92bh/VJHhI="},
-      #     {"x-amz-request-id", "QRENBY1MJTQWD7CZ"},
-      #     {"Date", "Tue, 13 Jun 2023 10:22:44 GMT"},
-      #     {"x-amz-expiration",
-      #      "expiry-date=\"Thu, 15 Jun 2023 00:00:00 GMT\", rule-id=\"delete-after-1-day\""},
-      #     {"x-amz-server-side-encryption", "AES256"},
-      #     {"Content-Type", "application/xml"},
-      #     {"Transfer-Encoding", "chunked"},
-      #     {"Server", "AmazonS3"}
-      #   ],
-      #   status_code: 200
-      # }
-      # Fetch the contents of the returned XML string from `ex_aws`.
-      # This XML is parsed with `sweet_xml`:
-      # github.com/kbrw/sweet_xml#the-x-sigil
-      #
+
       # Fetching the URL of the returned file.
-      url = upload_response_body.body |> xpath(~x"//text()") |> List.to_string()
+      url = upload_response_body.body.location
 
       # Creating the compressed URL to return as well
       compressed_url = "#{compressed_baseurl()}#{file_name}"

--- a/lib/app_web/controllers/api_controller.ex
+++ b/lib/app_web/controllers/api_controller.ex
@@ -14,8 +14,7 @@ defmodule AppWeb.ApiController do
 
         {:error, :invalid_extension} ->
           render(conn |> put_status(400), %{
-            body:
-              "Error uploading file. The content type of the uploaded file is not valid."
+            body: "Error uploading file. The content type of the uploaded file is not valid."
           })
 
         {:error, :invalid_cid} ->

--- a/test/app/upload_test.exs
+++ b/test/app/upload_test.exs
@@ -34,6 +34,7 @@ defmodule App.UploadTest do
       url:
         "https://s3.eu-west-3.amazonaws.com/#{@original_bucket}/zb2rhe5aFXPKonoWchLRYo9yJDqWyUdUeTQ6MQQJsTWnzzNum.jpg"
     }
+
     assert App.Upload.upload(image) == {:ok, expected_response}
   end
 
@@ -43,11 +44,15 @@ defmodule App.UploadTest do
       filename: "corrupted.jpg",
       path: [:code.priv_dir(:app), "static", "images", "corrupted.jpg"] |> Path.join()
     }
+
     # Even though the jpeg is *deliberately* corrupted the upload & CID still works!!
-    expected_response =  %{
-      compressed_url: "https://s3.eu-west-3.amazonaws.com/#{@compressed_bucket}/zb2rhngHXWi8mR5YHX3Go4xDYpZqqcAtGefn8sktQMM7YzKEz.jpg",
-      url: "https://s3.eu-west-3.amazonaws.com/#{@original_bucket}/zb2rhngHXWi8mR5YHX3Go4xDYpZqqcAtGefn8sktQMM7YzKEz.jpg"
+    expected_response = %{
+      compressed_url:
+        "https://s3.eu-west-3.amazonaws.com/#{@compressed_bucket}/zb2rhngHXWi8mR5YHX3Go4xDYpZqqcAtGefn8sktQMM7YzKEz.jpg",
+      url:
+        "https://s3.eu-west-3.amazonaws.com/#{@original_bucket}/zb2rhngHXWi8mR5YHX3Go4xDYpZqqcAtGefn8sktQMM7YzKEz.jpg"
     }
+
     assert App.Upload.upload(image) == {:ok, expected_response}
   end
 
@@ -90,11 +95,11 @@ defmodule App.UploadTest do
     file_cid = "anything"
     file_extension = ".png"
     assert App.Upload.upload_file_to_s3(file_cid, file_extension, image) == {:error, :upload_fail}
-
   end
 
   test "check_file_binary_and_extension/1 with empty.pdf returns :invalid_cid" do
     filename = "empty.pdf"
+
     image = %Plug.Upload{
       content_type: "application/pdf",
       filename: filename,

--- a/test/app_web/api_test.exs
+++ b/test/app_web/api_test.exs
@@ -101,9 +101,10 @@ defmodule AppWeb.APITest do
 
   test "upload pdf", %{conn: conn} do
     conn = post(conn, ~p"/api/images", @valid_pdf_attrs)
+
     assert Map.get(Jason.decode!(response(conn, 400)), "errors") == %{
-      "detail" => "Uploaded file is not a valid image."
-    }
+             "detail" => "Uploaded file is not a valid image."
+           }
   end
 
   test "wrong file extension", %{conn: conn} do
@@ -135,7 +136,8 @@ defmodule AppWeb.APITest do
     conn = post(conn, ~p"/api/images", @invalid_content_type_image)
 
     assert Map.get(Jason.decode!(response(conn, 400)), "errors") == %{
-             "detail" => "Error uploading file. The content type of the uploaded file is not valid."
+             "detail" =>
+               "Error uploading file. The content type of the uploaded file is not valid."
            }
   end
 
@@ -143,7 +145,8 @@ defmodule AppWeb.APITest do
     conn = post(conn, ~p"/api/images", @empty_image)
 
     assert Map.get(Jason.decode!(response(conn, 400)), "errors") == %{
-             "detail" => "Error uploading file. The contents of the uploaded file may be empty or invalid."
+             "detail" =>
+               "Error uploading file. The contents of the uploaded file may be empty or invalid."
            }
   end
 


### PR DESCRIPTION
closes #130 

As @ndrean rightfully pointed out, this is due to [`ex_aws_s3`](https://github.com/ex-aws/ex_aws_s3/blob/main/CHANGELOG.md) changing the function, which parses the XML for us now.

All tests pass and this is sorely needed to work, so I can get https://github.com/dwyl/app/pull/341 properly tested and merged. 